### PR TITLE
Adds Travis CI config file, resolves #14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+dist: xenial
+language: python
+python:
+  - "3.6"
+  - "3.7"
+install:
+  - pip install -r requirements-lock.txt
+script:
+  - echo "Hello, World!"


### PR DESCRIPTION
For #14: this adds a Travis CI config file which tells the continuous integration workers to install our requirements and then just print something for now. We test this on both Python 3.6 as well as 3.7 since these seem reasonable versions to support for now.

Down the road we want to add our linters, code formatters, and tests here. Then Travis CI will run them all on every single commit and pull request we do and tell us if we are good to go or not.

@adolorosa you have to go to the Travis CI page, log in with your Github account, and connect this repository and enable it. Then we can test it by pushing another commit to this branch. Ping me when you enabled it. Thanks!